### PR TITLE
Add Tuscon Mesh

### DIFF
--- a/content/networks.md
+++ b/content/networks.md
@@ -48,6 +48,7 @@ You may also be interested in our [Twitter list](https://twitter.com/meshcenter/
 | Spokane Mesh           | Spokane, Washington        | <https://spokanemesh.net>             | <https://twitter.com/spokanemesh>     |
 | SudoMesh               | Oakland, California        | <https://sudoroom.org/wiki/Mesh>      | <https://twitter.com/sudomesh>        |
 | Toronto Mesh           | Toronto, Canada            | <https://tomesh.net>                  | <https://twitter.com/tomeshnet>       |
+| Tuscon Mesh            | Tuscon, Arizona            | <https://tucsonmesh.net>              | <https:/instagram.com/tucsonmesh>     |
 | Vancouver Mesh         | Vancouver, Canada          | <http://vanmesh.net>                  | <https://twitter.com/VanMeshNet>      |
 | Wireless Leiden        | Leiden, Netherlands        | <https://wirelessleiden.nl>           | -                                     |
 | WirelessPT             | Portugal                   | <https://wirelesspt.net>              | <https://twitter.com/wirelesspt>      |


### PR DESCRIPTION
see https://nycmesh.slack.com/archives/C02MB96L9/p1666054407499619 "We are a mesh network that started about a year ago here in Tucson, Arizona and we have benefited enormously from your docs and materials and advice we’ve gotten here on your Slack, so we wanted to share some exciting updates about our network - and ask you all some questions. We started by hooking up a connection between the community center we operate out of (Blacklidge Community Collective, BCC, bcctucson.org) and a local bike shop (BICAS). Eventually we got a grant from our local food bank, installed a 25 foot mast (donated by Channel Master) on the roof of our center and using LAP120 sector radios, Litebeams and Omnitiks, we’ve hooked up 10+ households in the surrounding neighborhoods to the BCC’s internet. We are about to get our own 1Gbps+ connection at a discounted rate from the datacenter down the street and continue to expand our network. We have copied the NYC Mesh docs and configgen to create our own Tucson Mesh-specific version. Check us out at tucsonmesh.net and instagram.com/tucsonmesh …"